### PR TITLE
Change content dropdown label on browse button process

### DIFF
--- a/src/components/browseButton/index.js
+++ b/src/components/browseButton/index.js
@@ -191,7 +191,7 @@ function getCurrentFileNames () {
 
     // a PDF name.
     text = $('#dropdownPdf .js-text').text()
-    let pdfName = (text !== 'PDF File' ? text : null)
+    let pdfName = (text !== getContentDropdownInitialText() ? text : null)
 
     // a Primary anno.
     text = $('#dropdownAnnoPrimary .js-text').text()
@@ -223,7 +223,7 @@ function getCurrentFileNames () {
 function setPDFDropdownList () {
 
     // Reset the state of the PDF dropdown.
-    $('#dropdownPdf .js-text').text('PDF File')
+    $('#dropdownPdf .js-text').text(getContentDropdownInitialText())
     $('#dropdownPdf li').remove()
 
     // Create and setup the dropdown menu.
@@ -278,4 +278,9 @@ function setAnnoDropdownList () {
 
     // Setup color pallets.
     setupColorPicker()
+}
+
+function getContentDropdownInitialText() {
+    let value = $('#dropdownPdf .js-text').data('initial-text')
+    return (value === undefined || value === '') ? 'PDF File' : value
 }

--- a/src/components/contentDropdown/index.js
+++ b/src/components/contentDropdown/index.js
@@ -12,6 +12,7 @@ export function setup ({
 }) {
 
     $('#dropdownPdf .js-text').text(initialText)
+    $('#dropdownPdf .js-text').data('initial-text', initialText)
 
     // TODO pdfという単語を削除したい..
 


### PR DESCRIPTION
I use `anno-ui` library in https://github.com/paperai/htmlanno , that uses the XHTML and Plain-text as content file.
But I cannot set `#dropdownPdf` button label  to other than 'PDF File' because it  is set and refered as 'PDF File' by anno-ui code statically.
I want to set other than 'PDF File' to `#dropdownPdf` button label.

1. In contentDropdown, set initialText to HTML tag(= `#dropdownPdf` ) attribute as 'data-initial-text'.
1. In browseButton process, Use  `#dropdownPdf` 's 'data-initial-text' value as button initial label.