### PR TITLE
Add a callback with currentFileNames on browseButton process.

### DIFF
--- a/src/components/browseButton/index.js
+++ b/src/components/browseButton/index.js
@@ -37,7 +37,6 @@ let _displayCurrentPrimaryAnnotations
 let _getContentFiles
 let _getAnnoFiles
 let _closePDFViewer
-let _restoreBeforeStatus
 
 /**
  * Setup the behavior of a Browse Button.
@@ -50,14 +49,13 @@ export function setup ({
     getContentFiles,
     getAnnoFiles,
     closePDFViewer,
-    restoreBeforeStatus
+    callbackLoadedFiles
 }) {
     _displayCurrentReferenceAnnotations = displayCurrentReferenceAnnotations
     _displayCurrentPrimaryAnnotations = displayCurrentPrimaryAnnotations
     _getContentFiles = getContentFiles
     _getAnnoFiles = getAnnoFiles
     _closePDFViewer = closePDFViewer
-    _restoreBeforeStatus = restoreBeforeStatus
 
     // Enable to select the same directory twice or more.
     $('.js-file :file').on('click', ev => {
@@ -90,7 +88,8 @@ export function setup ({
 
             // Display a PDF and annotations.
             restoreBeforeState(current)
-            _restoreBeforeStatus(current)
+
+            callbackLoadedFiles && callbackLoadedFiles(current)
         })
     })
 }

--- a/src/components/browseButton/index.js
+++ b/src/components/browseButton/index.js
@@ -37,6 +37,7 @@ let _displayCurrentPrimaryAnnotations
 let _getContentFiles
 let _getAnnoFiles
 let _closePDFViewer
+let _restoreBeforeStatus
 
 /**
  * Setup the behavior of a Browse Button.
@@ -48,13 +49,15 @@ export function setup ({
     displayCurrentPrimaryAnnotations,
     getContentFiles,
     getAnnoFiles,
-    closePDFViewer
+    closePDFViewer,
+    restoreBeforeStatus
 }) {
     _displayCurrentReferenceAnnotations = displayCurrentReferenceAnnotations
     _displayCurrentPrimaryAnnotations = displayCurrentPrimaryAnnotations
     _getContentFiles = getContentFiles
     _getAnnoFiles = getAnnoFiles
     _closePDFViewer = closePDFViewer
+    _restoreBeforeStatus = restoreBeforeStatus
 
     // Enable to select the same directory twice or more.
     $('.js-file :file').on('click', ev => {
@@ -87,6 +90,7 @@ export function setup ({
 
             // Display a PDF and annotations.
             restoreBeforeState(current)
+            _restoreBeforeStatus(current)
         })
     })
 }


### PR DESCRIPTION
In Htmlanno, "Anno File" and "Reference Files" elements need to change by selected "Content File(PDF File)". Because In case of content file is BIOES format, only displaying BIOES annotation, and other case, NOT displaying BIOES annotation.